### PR TITLE
TRI-132/Implement Stop Tracking Modal

### DIFF
--- a/src/components/ModalStopTracking/ModalStopTracking.tsx
+++ b/src/components/ModalStopTracking/ModalStopTracking.tsx
@@ -22,7 +22,7 @@ const ModalStop: React.FC<ModalStopProps> = ({ onStop, onClose, show }) => {
         <div className="max-w-[539px] w-[92%] min-w-[310px] min-h-[199px] bg-gray-500 border border-gray-300 px-8 py-6 rounded-xl shadow-lg text-white">
           <div className="flex justify-between w-[100%]">
             <h5 className="font-normal mb-2" style={{ fontSize: '24px' }}>
-              Remove Member
+              Stop Tracking
             </h5>
             <button
               className="h-fit hidden sm:block"
@@ -51,9 +51,9 @@ const ModalStop: React.FC<ModalStopProps> = ({ onStop, onClose, show }) => {
               Cancel
             </Button>
             <Button
-              variant="error"
+              variant="filled"
               size={'large'}
-              className="w-[225px] h-fit"
+              className="w-[225px] h-fit text-black"
               onClick={() => {
                 onStop()
               }}

--- a/src/components/ModalStopTracking/ModalStopTracking.tsx
+++ b/src/components/ModalStopTracking/ModalStopTracking.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { Modal } from '@components/Modal/Modal'
+import Button from '@components/Button/Button'
+import Icon from '@components/Icon/Icon'
+import Body2 from '@utils/typography/body2/body2'
+
+export interface ModalStopProps {
+  onStop: () => void
+  onClose: () => void
+  show: boolean
+}
+
+const ModalStop: React.FC<ModalStopProps> = ({ onStop, onClose, show }) => {
+  return (
+    <>
+      <Modal
+        show={show}
+        onClose={() => {
+          onClose()
+        }}
+      >
+        <div className="max-w-[539px] w-[92%] min-w-[310px] min-h-[199px] bg-gray-500 border border-gray-300 px-8 py-6 rounded-xl shadow-lg text-white">
+          <div className="flex justify-between w-[100%]">
+            <h5 className="font-normal mb-2" style={{ fontSize: '24px' }}>
+              Remove Member
+            </h5>
+            <button
+              className="h-fit hidden sm:block"
+              onClick={() => {
+                onClose()
+              }}
+            >
+              <Icon name="DismissIcon" />
+            </button>
+          </div>
+          <Body2 className="text-sm font-normal mb-5">
+            You are currently tracking time for a ticket. To view information on
+            another ticket, you&apos;ll need to pause the current time tracking.
+            Are you sure you want to stop tracking time for the current ticket
+            and proceed?
+          </Body2>
+          <div className="flex justify-center gap-6">
+            <Button
+              variant="outline"
+              size={'large'}
+              className="w-[225px] h-fit"
+              onClick={() => {
+                onClose()
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="error"
+              size={'large'}
+              className="w-[225px] h-fit"
+              onClick={() => {
+                onStop()
+              }}
+            >
+              Stop Tracking
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  )
+}
+
+export default ModalStop

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -41,7 +41,6 @@ const LoginPage = (): JSX.Element => {
       <div className="hidden md:flex justify-end items-end h-screen w-full ">
         <img src={LoginImage} alt="Login image" />
       </div>
-
     </div>
   )
 }

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -41,6 +41,7 @@ const LoginPage = (): JSX.Element => {
       <div className="hidden md:flex justify-end items-end h-screen w-full ">
         <img src={LoginImage} alt="Login image" />
       </div>
+
     </div>
   )
 }


### PR DESCRIPTION
# Pull Request

## Description
The modal will inform users that they are currently tracking time for a ticket and to view information on another ticket, they need to pause the current time tracking. It will prompt users to confirm if they want to stop tracking the current ticket before proceeding.

## Ticket Link
[https://linear.app/tricker-sirius/issue/TRI-132/implement-the-stop-tracking-modal](url)

## Steps to Reproduce
1. In Login add: 

```
import ModalStop from '@components/ModalStopTracking/ModalStopTracking'

const LoginPage = (): JSX.Element => {
...
const [showModal, setShowModal] = useState(false)
...
}



...
<NeedHelpButton />
<button
            onClick={() => {
              setShowModal(true)
            }}
            className="text-white"
          >
            open modal
          </button>
          <ModalStop
            show={showModal}
            onStop={() => {}}
            onClose={() => {
              setShowModal(false)
            }}
/>
```
2. `npm run dev`
3. Click in button open modal to see the ModalComponent

## Images/Screenshots
![image](https://github.com/sirius-valley/tricker-front/assets/99856968/2a36e0ee-e8a5-4bff-925f-390053c91664)
