### PR TITLE
Tri 144/implementation of profile and logout popover menu

### DIFF
--- a/src/components/HomeWrapperPage/HomeWrapperPage.tsx
+++ b/src/components/HomeWrapperPage/HomeWrapperPage.tsx
@@ -3,12 +3,16 @@ import { SidebarNav } from '@components/SidebarNav/SidebarNav'
 import useScreenSize from '@hooks/useScreenSize'
 import React from 'react'
 import { Outlet } from 'react-router-dom'
+import { useUser } from '@redux/hooks'
 
 const HomeWrapperPage: React.FC = (): JSX.Element => {
   const screen = useScreenSize()
+  const user = useUser()
+
   return screen.width >= 768 ? (
     <div className="bg-gray-500 h-screen w-screen flex items-center justify-center">
       <SidebarNav
+        user={user}
         variant={'pm'}
         dropdownOptions={[]}
         handleDropdownSelect={function (): void {}}

--- a/src/components/HomeWrapperPage/HomeWrapperPage.tsx
+++ b/src/components/HomeWrapperPage/HomeWrapperPage.tsx
@@ -3,16 +3,12 @@ import { SidebarNav } from '@components/SidebarNav/SidebarNav'
 import useScreenSize from '@hooks/useScreenSize'
 import React from 'react'
 import { Outlet } from 'react-router-dom'
-import { useUser } from '@redux/hooks'
 
 const HomeWrapperPage: React.FC = (): JSX.Element => {
   const screen = useScreenSize()
-  const user = useUser()
-
   return screen.width >= 768 ? (
     <div className="bg-gray-500 h-screen w-screen flex items-center justify-center">
       <SidebarNav
-        user={user}
         variant={'pm'}
         dropdownOptions={[]}
         handleDropdownSelect={function (): void {}}

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -1,0 +1,34 @@
+import { type Meta, type StoryObj } from '@storybook/react'
+import Popover from './Popover'
+import { MemoryRouter } from 'react-router-dom'
+import { Provider } from 'react-redux'
+import { store } from '@redux/store'
+
+const meta: Meta<typeof Popover> = {
+  title: 'Components/Popover',
+  component: Popover,
+  decorators: [
+    (story) => <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>,
+    (Story) => <Provider store={store}>{Story()}</Provider>
+  ],
+  tags: ['autodocs'],
+  argTypes: {
+    show: {
+      control: {
+        type: 'boolean'
+      }
+    }
+  }
+}
+
+export default meta
+
+type Story = StoryObj<typeof Popover>
+
+export const Popovers: Story = {
+  tags: ['autodocs'],
+  args: {
+    userId: '213'
+  },
+  render: (args) => <Popover show={true} {...args} />
+}

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import HelperText from '@utils/typography/helpertext/helpertext'
+import { Link, useNavigate } from 'react-router-dom'
+import { setUser, initialState } from '@redux/user'
+import { useAppDispatch } from '@redux/hooks'
+import { removeLoginCookies } from '@data-provider/Cookies'
+import useScreenSize from '@hooks/useScreenSize'
+
+export interface PopoverProps {
+  userId: string // To redirect to the user profile in the future
+  show?: boolean
+}
+
+const Popover: React.FC<PopoverProps> = ({ show = false }) => {
+  const dispatch = useAppDispatch()
+  const screen = useScreenSize()
+  const navigate = useNavigate()
+
+  const handleLogout = (): void => {
+    dispatch(setUser(initialState.user))
+    removeLoginCookies()
+    navigate('/login')
+  }
+
+  return (
+    <div>
+      {show && screen.width > 500 && (
+        <div className="pb-2">
+          <div className="w-[184px] h-[62px] rounded-lg bg-gray-400 border border-[#939393] flex flex-col text-white">
+            <Link
+              to=""
+              className="w-full h-1/2 flex items-center py-2 px-4 hover:bg-[#93939393] rounded-t-lg"
+            >
+              <HelperText> View profile </HelperText>
+            </Link>
+            <button
+              className="w-full h-1/2 flex items-center py-2 px-4 hover:bg-[#93939393] rounded-b-lg"
+              onClick={() => {
+                handleLogout()
+              }}
+            >
+              <HelperText> Log out </HelperText>
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Popover

--- a/src/components/ProfilePicture/ProfilePicture.tsx
+++ b/src/components/ProfilePicture/ProfilePicture.tsx
@@ -18,14 +18,13 @@ interface ProfilePictureProps
   extends VariantProps<typeof profilePictureVariants>,
     React.HTMLAttributes<HTMLImageElement> {
   className?: string
-  img: string
+  img?: string
   border?: boolean
-  onClick?: () => void
 }
 
 export const ProfilePicture: React.FC<ProfilePictureProps> = ({
-  className = '',
-  img,
+  className,
+  img = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png',
   border = false,
   size = 'sm'
 }) => {

--- a/src/components/SidebarNav/Sidebar.stories.tsx
+++ b/src/components/SidebarNav/Sidebar.stories.tsx
@@ -2,7 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react'
 import { SidebarNav } from './SidebarNav'
 import { MemoryRouter } from 'react-router-dom'
 import { type DropdownOption } from '@components/Dropdown/Dropdown'
-import { type User, type TimeTracking, type Issue } from '@utils/types'
+import { type TimeTracking, type Issue } from '@utils/types'
 
 const dropdownOptions = [
   { title: 'Option 1', image: 'https://imageplaceholder.net/20x20' },
@@ -10,12 +10,6 @@ const dropdownOptions = [
   { title: 'Option 3', image: 'https://imageplaceholder.net/20x20' },
   { title: 'Option 4', image: 'https://imageplaceholder.net/20x20' }
 ]
-
-const user: User = {
-  name: 'Victoria Capurro',
-  email: 'victoriacapurro@sirius.com.ar',
-  id: '123'
-}
 
 const handleDropdownSelect = (option: DropdownOption): void => {
   console.log(option)
@@ -37,10 +31,6 @@ const meta: Meta<typeof SidebarNav> = {
   ],
   tags: ['autodocs'],
   argTypes: {
-    user: {
-      description: 'User information.',
-      defaultValue: user
-    },
     dropdownOptions: {
       description: 'Options for the dropdown.',
       defaultValue: dropdownOptions
@@ -74,7 +64,6 @@ export const DevView: Story = {
   tags: ['autodocs'],
   args: {
     variant: 'dev',
-    user,
     dropdownOptions,
     handleDropdownSelect,
     timeTracking
@@ -86,7 +75,6 @@ export const PMView: Story = {
   tags: ['autodocs'],
   args: {
     variant: 'pm',
-    user,
     dropdownOptions,
     handleDropdownSelect,
     timeTracking

--- a/src/components/SidebarNav/SidebarNav.tsx
+++ b/src/components/SidebarNav/SidebarNav.tsx
@@ -1,5 +1,5 @@
 import '../../index.css'
-import React from 'react'
+import React, { useState } from 'react'
 // import { Dropdown } from '@components/Dropdown/Dropdown'
 import TrickerLogo from '@assets/TrickerLogo'
 import TrickerTitle from '@assets/TrickerTitle'
@@ -10,10 +10,11 @@ import { ProfilePicture } from '@components/ProfilePicture/ProfilePicture'
 import Body1 from '@utils/typography/body1/body1'
 import { NavLink } from 'react-router-dom'
 import { type TimeTracking, type User } from '@utils/types'
+import Popover from '@components/Popover/Popover'
 
 export interface SidebarNavProps
   extends React.HTMLAttributes<HTMLInputElement> {
-  user?: User
+  user: User
   variant: 'pm' | 'dev'
   timeTracking?: TimeTracking
   dropdownOptions: Array<{ title: string; image: string }>
@@ -27,6 +28,8 @@ export const SidebarNav: React.FC<SidebarNavProps> = ({
   timeTracking
   // handleDropdownSelect
 }) => {
+  const [isHovered, setIsHovered] = useState(false)
+
   return (
     <div className="flex flex-col w-[224px] h-screen pt-10 gap-20 bg-gray-500">
       <NavLink to="/">
@@ -102,17 +105,26 @@ export const SidebarNav: React.FC<SidebarNavProps> = ({
         </div>
         <div className="flex flex-col items-center gap-2">
           {timeTracking && <TimeTrackingBadge ticketId={timeTracking.id} />}
-          <NavLink to={'/user/' + user?.id}>
+          <div
+            className="flex flex-col items-center h-fit w-fit"
+            onMouseEnter={() => {
+              setIsHovered(true)
+            }}
+            onMouseLeave={() => {
+              setIsHovered(false)
+            }}
+          >
+            <Popover userId={user?.id} show={isHovered} />
             <div className="flex items-center p-2 gap-3 max-w-[224px]">
               <ProfilePicture
                 className="min-w-10 min-h-10"
-                img="https://s3-alpha-sig.figma.com/img/4fe8/a23d/ddeece2a91e7cc5919fd149d572c6d1e?Expires=1708905600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=a33zUweOtCPNcY1RYMBSl7M0W3HvLrpSgGfHnnqS-~FBATDlE42BrkMOby65VNWC2eo3p7sknPz1zjtO3xZfNT4zZyke6ZRrYV1k2nllK6NJMDzTKFn~qe4R0xWUtyxxWtauAlAvqmDY7G2O417AE05nFyFXyLlo7zePBrxsCNWm9f3jD2W65zFwgLy8wzcy5ryT5OZPA5wxOXPXN-6-VngmrBmoZqg-SWVfgL-E6W3GkoLj4IvMi7LcJZ162JsXmP0o-mHJ4bRi9K04k3ACjyg7BT2f9fCLbGzy5Nddzk8p61tDl7OczzCY-K9bx0ju3uAbhMnWfpFU0vcp7gpOcw__"
+                img={user?.profileImage}
               />
               <Body1 className="text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
-                {user?.name}
+                {user?.name || 'User name'}
               </Body1>
             </div>
-          </NavLink>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/SidebarNav/SidebarNav.tsx
+++ b/src/components/SidebarNav/SidebarNav.tsx
@@ -9,12 +9,12 @@ import TimeTrackingBadge from '@components/TimeTrackingBadge/TimeTrackingBadge'
 import { ProfilePicture } from '@components/ProfilePicture/ProfilePicture'
 import Body1 from '@utils/typography/body1/body1'
 import { NavLink } from 'react-router-dom'
-import { type TimeTracking, type User } from '@utils/types'
+import { type TimeTracking } from '@utils/types'
 import Popover from '@components/Popover/Popover'
+import { useUser } from '@redux/hooks'
 
 export interface SidebarNavProps
   extends React.HTMLAttributes<HTMLInputElement> {
-  user: User
   variant: 'pm' | 'dev'
   timeTracking?: TimeTracking
   dropdownOptions: Array<{ title: string; image: string }>
@@ -22,13 +22,13 @@ export interface SidebarNavProps
 }
 
 export const SidebarNav: React.FC<SidebarNavProps> = ({
-  user,
   variant,
   // dropdownOptions,
   timeTracking
   // handleDropdownSelect
 }) => {
   const [isHovered, setIsHovered] = useState(false)
+  const user = useUser()
 
   return (
     <div className="flex flex-col w-[224px] h-screen pt-10 gap-20 bg-gray-500">

--- a/src/redux/user.tsx
+++ b/src/redux/user.tsx
@@ -8,7 +8,7 @@ interface InitialStateType {
   projectName: string
 }
 
-const initialState: InitialStateType = {
+export const initialState: InitialStateType = {
   user: {
     id: '',
     cognitoId: '',


### PR DESCRIPTION
# Pull Request

## Description
Added Popover component in the Sidebar

## Ticket Link
[[TRI-144]](https://linear.app/tricker-sirius/issue/TRI-144/implementation-of-profile-and-logout-popover-menu)

## Steps to Reproduce
1. `yarn dev`
2. Log in and go to the home
3. Hover the user info in the SidebarNav component

## Images/Screenshots (if necessary)
![image](https://github.com/sirius-valley/tricker-front/assets/87399661/d44b5272-6abb-4c56-b1ee-dbca6a311f8a)
