### PR TITLE
TRI-180: Frontend implementation for card blocking

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -87,7 +87,6 @@ const Input = ({
             className={`${variant === 'disabled' ? 'text-gray-300' : 'text-white'} flex items-center text-sm font-normal`}
           >
             {label}
-            &nbsp;
           </Body2>
           {tooltip !== '' && (
             <Tooltip content={tooltip} iconWidth="16" iconHeight="16" />

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -53,7 +53,9 @@ const Input = ({
   handleValue,
   placeholder = '',
   tooltip = '',
-  defaultValue = ''
+  defaultValue = '',
+  onFocus,
+  onBlur
 }: InputProps): JSX.Element => {
   const [inputValue, setInputValue] = useState<string>(value)
 
@@ -106,6 +108,8 @@ const Input = ({
         placeholder={placeholder}
         onChange={handleChange}
         disabled={variant === 'disabled'}
+        onFocus={onFocus}
+        onBlur={onBlur}
       />
 
       {helpertext !== '' && (

--- a/src/components/InputAutocomplete/InputAutocomplete.stories.tsx
+++ b/src/components/InputAutocomplete/InputAutocomplete.stories.tsx
@@ -1,0 +1,83 @@
+import { type Meta, type StoryObj } from '@storybook/react'
+import InputAutocomplete from './InputAutocomplete'
+import { store } from '@redux/store'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { SnackBarProvider } from '@components/SnackBarProvider/SnackBarProvider'
+
+const queryClient = new QueryClient()
+
+const meta: Meta<typeof InputAutocomplete> = {
+  title: 'Components/InputAutocomplete',
+  component: InputAutocomplete,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <SnackBarProvider>
+        <Provider store={store}>
+          <QueryClientProvider client={queryClient}>
+            {Story()}
+          </QueryClientProvider>
+        </Provider>
+      </SnackBarProvider>
+    )
+  ],
+  argTypes: {
+    variant: {
+      defaultValue: 'default',
+      options: ['default', 'error', 'disabled'],
+      control: {
+        type: 'select'
+      }
+    },
+    type: {
+      defaultValue: ['text'],
+      options: ['text', 'password'],
+      control: {
+        type: 'radio'
+      }
+    },
+    label: {
+      defaultValue: 'InputAutocomplete Label Text',
+      control: {
+        type: 'text'
+      }
+    },
+    helpertext: {
+      defaultValue: 'InputAutocomplete Helper Text',
+      control: {
+        type: 'text'
+      }
+    },
+    placeholder: {
+      defaultValue: 'This Input is quite long',
+      control: {
+        type: 'text'
+      }
+    },
+    required: {
+      defaultValue: true,
+      control: {
+        type: 'boolean'
+      }
+    }
+  }
+}
+
+export default meta
+
+type Story = StoryObj<typeof InputAutocomplete>
+
+export const Default: Story = {
+  tags: ['autodocs'],
+  args: {
+    variant: 'default',
+    label: 'InputAutocomplete Label Text',
+    placeholder: 'This Input is quite long',
+    helpertext: 'InputAutocomplete Label Text',
+    type: 'text',
+    required: true,
+    icon: ''
+  },
+  render: (args) => <InputAutocomplete {...args} />
+}

--- a/src/components/InputAutocomplete/InputAutocomplete.tsx
+++ b/src/components/InputAutocomplete/InputAutocomplete.tsx
@@ -12,7 +12,8 @@ const InputAutocomplete = ({
   readonly = false,
   placeholder = '',
   tooltip = '',
-  defaultValue = ''
+  defaultValue = '',
+  handleValue
 }: InputProps): JSX.Element => {
   const [query, setQuery] = useState<string>('')
   const [showModal, setShowModal] = useState<boolean>(false)
@@ -45,6 +46,7 @@ const InputAutocomplete = ({
 
   const handleSelect = (option: string): void => {
     setQuery(option)
+    handleValue(option)
     setShowModal(false)
   }
 

--- a/src/components/InputAutocomplete/InputAutocomplete.tsx
+++ b/src/components/InputAutocomplete/InputAutocomplete.tsx
@@ -69,6 +69,11 @@ const InputAutocomplete = ({
     setShowModal(false)
   }
 
+  const handleChange = (value: string): void => {
+    setQuery(value)
+    handleValue(value)
+  }
+
   return (
     <div className="relative" ref={resultsRef}>
       <Input
@@ -83,7 +88,7 @@ const InputAutocomplete = ({
         label={label}
         required={required}
         readonly={readonly}
-        handleValue={setQuery}
+        handleValue={handleChange}
         placeholder={placeholder}
         tooltip={tooltip}
         defaultValue={defaultValue}

--- a/src/components/InputAutocomplete/InputAutocomplete.tsx
+++ b/src/components/InputAutocomplete/InputAutocomplete.tsx
@@ -1,0 +1,73 @@
+import Input, { type InputProps } from '@components/Input/Input'
+import ModalSearchResult from '@components/ModalSearchResult/ModalSearchResult'
+import useDebounce from '@hooks/useDebounce'
+import { useState, useEffect } from 'react'
+
+const InputAutocomplete = ({
+  value = '',
+  className,
+  variant,
+  type = 'text',
+  helpertext = '',
+  label = '',
+  required = false,
+  readonly = false,
+  placeholder = '',
+  tooltip = '',
+  defaultValue = ''
+}: InputProps): JSX.Element => {
+  const [query, setQuery] = useState<string>('')
+  const [showModal, setShowModal] = useState<boolean>(false)
+
+  const handleSearchDebounced = useDebounce((query: string) => {
+    console.log(query)
+    // mutate({query})
+  }, 300)
+
+  useEffect(() => {
+    handleSearchDebounced(query)
+  }, [query])
+
+  //   const handleClick = () => {
+  //     if (inputRef.current) {
+  //       inputRef.current.focus()
+  //       setIsOpen(true)
+  //     }
+  //   }
+
+  const handleSelect = (option: string): void => {
+    setQuery(option)
+    setShowModal(false)
+  }
+
+  return (
+    <div>
+      <Input
+        value={value}
+        className={className}
+        variant={variant}
+        type={type}
+        helpertext={helpertext}
+        label={label}
+        required={required}
+        readonly={readonly}
+        handleValue={setQuery}
+        placeholder={placeholder}
+        tooltip={tooltip}
+        defaultValue={defaultValue}
+      />
+      {query !== '' && showModal && (
+        <ModalSearchResult
+          show={showModal}
+          results={[]}
+          handleClick={handleSelect}
+          onClose={() => {
+            setShowModal(false)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+export default InputAutocomplete

--- a/src/components/InputAutocomplete/InputAutocomplete.tsx
+++ b/src/components/InputAutocomplete/InputAutocomplete.tsx
@@ -17,7 +17,7 @@ const InputAutocomplete = ({
   defaultValue = ''
 }: InputProps): JSX.Element => {
   const [query, setQuery] = useState<string>('')
-  const [showModal, setShowModal] = useState<boolean>(false)
+  const [showModal, setShowModal] = useState<boolean>(true)
 
   const handleSearchDebounced = useDebounce((query: string) => {
     console.log(query)
@@ -37,11 +37,11 @@ const InputAutocomplete = ({
 
   const handleSelect = (option: string): void => {
     setQuery(option)
-    setShowModal(false)
+    setShowModal(true)
   }
 
   return (
-    <div>
+    <div className="relative">
       <Input
         value={value}
         className={className}
@@ -59,7 +59,7 @@ const InputAutocomplete = ({
       {query !== '' && showModal && (
         <ModalSearchResult
           show={showModal}
-          results={[]}
+          results={['opcion 1', 'opcion 2', 'opcion 3', 'opcion 4', 'opcion 5']}
           handleClick={handleSelect}
           onClose={() => {
             setShowModal(false)

--- a/src/components/InputAutocomplete/InputAutocomplete.tsx
+++ b/src/components/InputAutocomplete/InputAutocomplete.tsx
@@ -88,16 +88,14 @@ const InputAutocomplete = ({
         tooltip={tooltip}
         defaultValue={defaultValue}
       />
-      {query !== '' && (
-        <ModalSearchResult
-          show={showModal}
-          results={data ?? []}
-          handleClick={handleSelect}
-          onClose={() => {
-            setShowModal(false)
-          }}
-        />
-      )}
+      <ModalSearchResult
+        show={showModal}
+        results={data ?? []}
+        handleClick={handleSelect}
+        onClose={() => {
+          setShowModal(false)
+        }}
+      />
     </div>
   )
 }

--- a/src/components/InputAutocomplete/InputAutocomplete.tsx
+++ b/src/components/InputAutocomplete/InputAutocomplete.tsx
@@ -4,6 +4,7 @@ import { useSnackBar } from '@components/SnackBarProvider/SnackBarProvider'
 import { handleErrorMessage } from '@data-provider/AxiosError'
 import { useGetIssuesByTitle } from '@data-provider/query'
 import useDebounce from '@hooks/useDebounce'
+import { useCurrentProjectId, useUser, useUserRole } from '@redux/hooks'
 import { useState, useEffect, useRef, useCallback } from 'react'
 
 const InputAutocomplete = ({
@@ -19,6 +20,9 @@ const InputAutocomplete = ({
   handleValue
 }: InputProps): JSX.Element => {
   const { showSnackBar } = useSnackBar()
+  const userRole = useUserRole()
+  const user = useUser()
+  const currentProjectId = useCurrentProjectId()
   const memoizedShowSnackBar = useCallback(showSnackBar, [showSnackBar])
   const [query, setQuery] = useState<string>('')
   const [showModal, setShowModal] = useState<boolean>(false)
@@ -28,7 +32,12 @@ const InputAutocomplete = ({
   const { mutate, error, data } = useGetIssuesByTitle()
 
   const handleSearchDebounced = useDebounce((query: string) => {
-    mutate({ issueName: query })
+    mutate({
+      isProjectManager: userRole === 'Project Manager',
+      userId: user.id,
+      projectId: currentProjectId,
+      issueName: query
+    })
   }, 300)
 
   useEffect(() => {

--- a/src/components/InputAutocomplete/InputAutocomplete.tsx
+++ b/src/components/InputAutocomplete/InputAutocomplete.tsx
@@ -7,6 +7,10 @@ import useDebounce from '@hooks/useDebounce'
 import { useCurrentProjectId, useUser, useUserRole } from '@redux/hooks'
 import { useState, useEffect, useRef, useCallback } from 'react'
 
+interface InputAutocompleteProps extends InputProps {
+  issueName: string
+}
+
 const InputAutocomplete = ({
   className,
   variant,
@@ -17,8 +21,9 @@ const InputAutocomplete = ({
   placeholder = '',
   tooltip = '',
   defaultValue = '',
-  handleValue
-}: InputProps): JSX.Element => {
+  handleValue,
+  issueName
+}: InputAutocompleteProps): JSX.Element => {
   const { showSnackBar } = useSnackBar()
   const userRole = useUserRole()
   const user = useUser()
@@ -36,7 +41,8 @@ const InputAutocomplete = ({
       isProjectManager: userRole === 'Project Manager',
       userId: user.id,
       projectId: currentProjectId,
-      issueName: query
+      issueName,
+      searchedText: query
     })
   }, 600)
 

--- a/src/components/InputAutocomplete/InputAutocomplete.tsx
+++ b/src/components/InputAutocomplete/InputAutocomplete.tsx
@@ -18,7 +18,7 @@ const InputAutocomplete = ({
 }: InputProps): JSX.Element => {
   const [query, setQuery] = useState<string>('')
   const [showModal, setShowModal] = useState<boolean>(true)
-
+  console.log(showModal)
   const handleSearchDebounced = useDebounce((query: string) => {
     console.log(query)
     // mutate({query})
@@ -56,9 +56,8 @@ const InputAutocomplete = ({
         tooltip={tooltip}
         defaultValue={defaultValue}
       />
-      {query !== '' && showModal && (
+      {query !== '' && (
         <ModalSearchResult
-          show={showModal}
           results={['opcion 1', 'opcion 2', 'opcion 3', 'opcion 4', 'opcion 5']}
           handleClick={handleSelect}
           onClose={() => {

--- a/src/components/InputAutocomplete/InputAutocomplete.tsx
+++ b/src/components/InputAutocomplete/InputAutocomplete.tsx
@@ -38,7 +38,7 @@ const InputAutocomplete = ({
       projectId: currentProjectId,
       issueName: query
     })
-  }, 300)
+  }, 600)
 
   useEffect(() => {
     handleSearchDebounced(query)

--- a/src/components/ModalBlock/ModalBlock.tsx
+++ b/src/components/ModalBlock/ModalBlock.tsx
@@ -15,12 +15,14 @@ interface ModalBlockProps {
   setIsBlocked: (isBlocked: boolean) => void
   onClose: () => void
   show: boolean
+  issueName: string
 }
 
 const ModalBlock: React.FC<ModalBlockProps> = ({
   setIsBlocked,
   onClose,
-  show
+  show,
+  issueName
 }) => {
   const [selectedReason, setSelectedReason] = useState<string>('')
   const [selectedComment, setSelectedComment] = useState<string>('')
@@ -145,6 +147,7 @@ const ModalBlock: React.FC<ModalBlockProps> = ({
                 placeholder="TIK-292"
                 variant={'default'}
                 required
+                issueName={issueName}
                 helpertext={
                   selectedReason === 'Other' ? 'Please specify the reason' : ''
                 }

--- a/src/components/ModalBlock/ModalBlock.tsx
+++ b/src/components/ModalBlock/ModalBlock.tsx
@@ -129,7 +129,7 @@ const ModalBlock: React.FC<ModalBlockProps> = ({ onClose, show }) => {
                 handleValue={handleComment}
                 placeholder="TIK-292"
                 variant={'default'}
-                required={selectedReason === 'Other'}
+                required
                 helpertext={
                   selectedReason === 'Other' ? 'Please specify the reason' : ''
                 }

--- a/src/components/ModalBlock/ModalBlock.tsx
+++ b/src/components/ModalBlock/ModalBlock.tsx
@@ -57,10 +57,7 @@ const ModalBlock: React.FC<ModalBlockProps> = ({
   }
 
   useEffect(() => {
-    if (
-      selectedReason === '' ||
-      (selectedReason === 'Other' && selectedComment === '')
-    ) {
+    if (selectedReason === '' || selectedComment === '') {
       setButtonDisabled(true)
     } else {
       setButtonDisabled(false)
@@ -82,7 +79,15 @@ const ModalBlock: React.FC<ModalBlockProps> = ({
       setToInitialValues()
       reset()
     }
-  }, [isSuccess, error, reset, memoizedShowSnackBar, onClose, selectedReason])
+  }, [
+    isSuccess,
+    error,
+    reset,
+    memoizedShowSnackBar,
+    onClose,
+    selectedReason,
+    selectedComment
+  ])
 
   const handleSubmitBlock = (): void => {
     if (selectedReason) {

--- a/src/components/ModalBlock/ModalBlock.tsx
+++ b/src/components/ModalBlock/ModalBlock.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import Input from '@components/Input/Input'
 import SelectInput from '@components/SelectInput/SelectInput'
 import Icon from '@components/Icon/Icon'
 import Body2 from '@utils/typography/body2/body2'
@@ -9,6 +8,7 @@ import { usePostBlock } from '@data-provider/query'
 import { useSnackBar } from '@components/SnackBarProvider/SnackBarProvider'
 import Spinner from '@components/Spinner/Spinner'
 import { useCurrentTicket } from '@redux/hooks'
+import InputAutocomplete from '@components/InputAutocomplete/InputAutocomplete'
 
 interface ModalBlockProps {
   onClose: () => void
@@ -124,10 +124,10 @@ const ModalBlock: React.FC<ModalBlockProps> = ({ onClose, show }) => {
                   required
                 />
               </div>
-              <Input
+              <InputAutocomplete
                 label="Other reason or Clarifications"
                 handleValue={handleComment}
-                placeholder="Blocked by TIK-292"
+                placeholder="TIK-292"
                 variant={'default'}
                 required={selectedReason === 'Other'}
                 helpertext={

--- a/src/components/ModalSearchResult/ItemDataBox/ItemDataBox.tsx
+++ b/src/components/ModalSearchResult/ItemDataBox/ItemDataBox.tsx
@@ -1,13 +1,11 @@
 import Body1 from '@utils/typography/body1/body1'
 
 interface ItemDataBoxProps {
-  key: string
   label: string
   onClick: (option: string) => void
 }
 const ItemDataBox: React.FC<ItemDataBoxProps> = ({
   label,
-  key,
   onClick
 }: ItemDataBoxProps): JSX.Element => {
   return (
@@ -16,7 +14,6 @@ const ItemDataBox: React.FC<ItemDataBoxProps> = ({
       onClick={() => {
         onClick(label)
       }}
-      key={key}
     >
       <Body1 className="text-white">{label}</Body1>
     </li>

--- a/src/components/ModalSearchResult/ItemDataBox/ItemDataBox.tsx
+++ b/src/components/ModalSearchResult/ItemDataBox/ItemDataBox.tsx
@@ -1,7 +1,7 @@
 import Body1 from '@utils/typography/body1/body1'
 
 interface ItemDataBoxProps {
-  key: number
+  key: string
   label: string
   onClick: (option: string) => void
 }

--- a/src/components/ModalSearchResult/ItemDataBox/ItemDataBox.tsx
+++ b/src/components/ModalSearchResult/ItemDataBox/ItemDataBox.tsx
@@ -1,0 +1,26 @@
+interface ItemDataBoxProps {
+  key: number
+  label: string
+  onClick: (option: string) => void
+}
+const ItemDataBox: React.FC<ItemDataBoxProps> = ({
+  label,
+  key,
+  onClick
+}: ItemDataBoxProps): JSX.Element => {
+  return (
+    <li
+      className="flex items-center relative cursor-pointer select-none rounded-xl px-4 hover:bg-gray-400/10 transition-colors duration-200"
+      onClick={() => {
+        onClick(label)
+      }}
+      key={key}
+    >
+      <span className="text-gray-600 leading-[22px] text-sm font-inter italic">
+        {label}
+      </span>
+    </li>
+  )
+}
+
+export default ItemDataBox

--- a/src/components/ModalSearchResult/ItemDataBox/ItemDataBox.tsx
+++ b/src/components/ModalSearchResult/ItemDataBox/ItemDataBox.tsx
@@ -1,3 +1,5 @@
+import Body1 from '@utils/typography/body1/body1'
+
 interface ItemDataBoxProps {
   key: number
   label: string
@@ -10,15 +12,13 @@ const ItemDataBox: React.FC<ItemDataBoxProps> = ({
 }: ItemDataBoxProps): JSX.Element => {
   return (
     <li
-      className="flex items-center relative cursor-pointer select-none rounded-xl px-4 hover:bg-gray-400/10 transition-colors duration-200"
+      className="flex w-full items-center relative cursor-pointer rounded hover:bg-gray-400 transition-colors duration-200 p-2 px-4 hover:shadow-button active:shadow-buttonClicked"
       onClick={() => {
         onClick(label)
       }}
       key={key}
     >
-      <span className="text-gray-600 leading-[22px] text-sm font-inter italic">
-        {label}
-      </span>
+      <Body1 className="text-white">{label}</Body1>
     </li>
   )
 }

--- a/src/components/ModalSearchResult/ModalSearchResult.tsx
+++ b/src/components/ModalSearchResult/ModalSearchResult.tsx
@@ -3,7 +3,7 @@ import ItemDataBox from './ItemDataBox/ItemDataBox'
 
 interface ModalSearchResultProps {
   show: boolean
-  results: string[]
+  results: Array<{ id: string; name: string }>
   handleClick: (value: string) => void
   onClose: () => void
 }
@@ -28,13 +28,17 @@ const ModalSearchResult: React.FC<ModalSearchResultProps> = ({
           onClick={handleClose}
         >
           {results.length === 0 ? (
-            <Body1 className="text-white">
+            <Body1 className="text-white w-full flex items-center p-2 px-4">
               No options matches with your search.
             </Body1>
           ) : (
             <ul className="flex flex-col gap-1 w-full p-0">
-              {results.map((item: string, index: number) => (
-                <ItemDataBox key={index} label={item} onClick={handleClick} />
+              {results.map((item: { id: string; name: string }) => (
+                <ItemDataBox
+                  key={item.id}
+                  label={item.name}
+                  onClick={handleClick}
+                />
               ))}
             </ul>
           )}

--- a/src/components/ModalSearchResult/ModalSearchResult.tsx
+++ b/src/components/ModalSearchResult/ModalSearchResult.tsx
@@ -2,12 +2,14 @@ import Body1 from '@utils/typography/body1/body1'
 import ItemDataBox from './ItemDataBox/ItemDataBox'
 
 interface ModalSearchResultProps {
+  show: boolean
   results: string[]
   handleClick: (value: string) => void
   onClose: () => void
 }
 
 const ModalSearchResult: React.FC<ModalSearchResultProps> = ({
+  show,
   results,
   handleClick,
   onClose
@@ -19,22 +21,26 @@ const ModalSearchResult: React.FC<ModalSearchResultProps> = ({
   }
 
   return (
-    <div
-      className="w-full bg-gray-500 rounded-b-xl py-2 border border-white/15"
-      onClick={handleClose}
-    >
-      {results.length === 0 ? (
-        <Body1 className="text-white">
-          No options matches with your search.
-        </Body1>
-      ) : (
-        <ul className="flex flex-col gap-1 w-full p-0">
-          {results.map((item: string, index: number) => (
-            <ItemDataBox key={index} label={item} onClick={handleClick} />
-          ))}
-        </ul>
+    <>
+      {show && (
+        <div
+          className="w-full bg-gray-500 rounded-b-xl py-2 border border-white/15"
+          onClick={handleClose}
+        >
+          {results.length === 0 ? (
+            <Body1 className="text-white">
+              No options matches with your search.
+            </Body1>
+          ) : (
+            <ul className="flex flex-col gap-1 w-full p-0">
+              {results.map((item: string, index: number) => (
+                <ItemDataBox key={index} label={item} onClick={handleClick} />
+              ))}
+            </ul>
+          )}
+        </div>
       )}
-    </div>
+    </>
   )
 }
 

--- a/src/components/ModalSearchResult/ModalSearchResult.tsx
+++ b/src/components/ModalSearchResult/ModalSearchResult.tsx
@@ -24,7 +24,7 @@ const ModalSearchResult: React.FC<ModalSearchResultProps> = ({
     <>
       {show && (
         <div
-          className="w-full bg-gray-500 rounded-b-xl py-2 border border-white/15"
+          className="absolute w-full bg-gray-500 rounded-b-xl py-2 border border-white/15"
           onClick={handleClose}
         >
           {results.length === 0 ? (

--- a/src/components/ModalSearchResult/ModalSearchResult.tsx
+++ b/src/components/ModalSearchResult/ModalSearchResult.tsx
@@ -34,11 +34,9 @@ const ModalSearchResult: React.FC<ModalSearchResultProps> = ({
           ) : (
             <ul className="flex flex-col gap-1 w-full p-0">
               {results.map((item: { id: string; name: string }) => (
-                <ItemDataBox
-                  key={item.id}
-                  label={item.name}
-                  onClick={handleClick}
-                />
+                <div key={item.id}>
+                  <ItemDataBox label={item.name} onClick={handleClick} />
+                </div>
               ))}
             </ul>
           )}

--- a/src/components/ModalSearchResult/ModalSearchResult.tsx
+++ b/src/components/ModalSearchResult/ModalSearchResult.tsx
@@ -1,4 +1,3 @@
-import ReactDom from 'react-dom'
 import ItemDataBox from './ItemDataBox/ItemDataBox'
 
 interface ModalSearchResultProps {
@@ -20,49 +19,33 @@ const ModalSearchResult: React.FC<ModalSearchResultProps> = ({
     }
   }
 
-  const portalElement = document.getElementById('portal')
-  if (!portalElement) {
-    return null
-  } else {
-    return ReactDom.createPortal(
-      <>
-        {show && (
-          <div
-            onClick={handleClose}
-            className="w-screen h-screen fixed top-0 left-0 bg-black bg-opacity-50 z-50 flex justify-center items-center"
-          >
-            <div className="w-full flex flex-col w-[360px] h-fit gap-2.5 pl-5 justify-center">
-              <div className="flex flex-col gap-2 w-full h-fit">
-                <div className="flex flex-col gap-2 p-4 bg-white z-50 rounded-b-3xl w-full">
-                  <div className="flex flex-col gap-2 w-full">
-                    <ul className="flex flex-col gap-2.5 h-full w-full">
-                      {results.map((item: string, index: number) => {
-                        return (
-                          <ItemDataBox
-                            key={index}
-                            label={item}
-                            onClick={handleClick}
-                          />
-                        )
-                      })}
-                    </ul>
-                  </div>
-                  {results.length === 0 && (
-                    <div className="flex items-center box-border h-fit pt-2.5 gap-2.5">
-                      <p className="font-bold text-sm italic font-inter leading-[22px] text-gray-600">
-                        No options matches with your search.
-                      </p>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
+  return (
+    <>
+      {show && (
+        <div
+          className="w-full flex flex-col w-full h-fit gap-2.5 justify-center"
+          onClick={handleClose}
+        >
+          <div className="flex flex-col gap-2 w-full bg-gray-300 rounded-b-3xl p-4">
+            <ul className="flex flex-col gap-2.5 h-full w-full">
+              {results.map((item: string, index: number) => {
+                return (
+                  <ItemDataBox key={index} label={item} onClick={handleClick} />
+                )
+              })}
+            </ul>
           </div>
-        )}
-      </>,
-      portalElement
-    )
-  }
+          {results.length === 0 && (
+            <div className="flex items-center box-border h-fit pt-2.5 gap-2.5">
+              <p className="font-bold text-sm italic font-inter leading-[22px] text-gray-600">
+                No options matches with your search.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  )
 }
 
 export default ModalSearchResult

--- a/src/components/ModalSearchResult/ModalSearchResult.tsx
+++ b/src/components/ModalSearchResult/ModalSearchResult.tsx
@@ -1,4 +1,5 @@
 import ReactDom from 'react-dom'
+import ItemDataBox from './ItemDataBox/ItemDataBox'
 
 interface ModalSearchResultProps {
   show: boolean
@@ -10,7 +11,7 @@ interface ModalSearchResultProps {
 const ModalSearchResult: React.FC<ModalSearchResultProps> = ({
   show,
   results,
-
+  handleClick,
   onClose
 }: ModalSearchResultProps): JSX.Element | null => {
   const handleClose = (event: React.MouseEvent): void => {
@@ -30,9 +31,32 @@ const ModalSearchResult: React.FC<ModalSearchResultProps> = ({
             onClick={handleClose}
             className="w-screen h-screen fixed top-0 left-0 bg-black bg-opacity-50 z-50 flex justify-center items-center"
           >
-            {results.map((option: string) => (
-              <div key={option}>{option}</div>
-            ))}
+            <div className="w-full flex flex-col w-[360px] h-fit gap-2.5 pl-5 justify-center">
+              <div className="flex flex-col gap-2 w-full h-fit">
+                <div className="flex flex-col gap-2 p-4 bg-white z-50 rounded-b-3xl w-full">
+                  <div className="flex flex-col gap-2 w-full">
+                    <ul className="flex flex-col gap-2.5 h-full w-full">
+                      {results.map((item: string, index: number) => {
+                        return (
+                          <ItemDataBox
+                            key={index}
+                            label={item}
+                            onClick={handleClick}
+                          />
+                        )
+                      })}
+                    </ul>
+                  </div>
+                  {results.length === 0 && (
+                    <div className="flex items-center box-border h-fit pt-2.5 gap-2.5">
+                      <p className="font-bold text-sm italic font-inter leading-[22px] text-gray-600">
+                        No options matches with your search.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
           </div>
         )}
       </>,

--- a/src/components/ModalSearchResult/ModalSearchResult.tsx
+++ b/src/components/ModalSearchResult/ModalSearchResult.tsx
@@ -1,14 +1,13 @@
+import Body1 from '@utils/typography/body1/body1'
 import ItemDataBox from './ItemDataBox/ItemDataBox'
 
 interface ModalSearchResultProps {
-  show: boolean
   results: string[]
   handleClick: (value: string) => void
   onClose: () => void
 }
 
 const ModalSearchResult: React.FC<ModalSearchResultProps> = ({
-  show,
   results,
   handleClick,
   onClose
@@ -20,31 +19,22 @@ const ModalSearchResult: React.FC<ModalSearchResultProps> = ({
   }
 
   return (
-    <>
-      {show && (
-        <div
-          className="w-full flex flex-col w-full h-fit gap-2.5 justify-center"
-          onClick={handleClose}
-        >
-          <div className="flex flex-col gap-2 w-full bg-gray-300 rounded-b-3xl p-4">
-            <ul className="flex flex-col gap-2.5 h-full w-full">
-              {results.map((item: string, index: number) => {
-                return (
-                  <ItemDataBox key={index} label={item} onClick={handleClick} />
-                )
-              })}
-            </ul>
-          </div>
-          {results.length === 0 && (
-            <div className="flex items-center box-border h-fit pt-2.5 gap-2.5">
-              <p className="font-bold text-sm italic font-inter leading-[22px] text-gray-600">
-                No options matches with your search.
-              </p>
-            </div>
-          )}
-        </div>
+    <div
+      className="w-full bg-gray-500 rounded-b-xl py-2 border border-white/15"
+      onClick={handleClose}
+    >
+      {results.length === 0 ? (
+        <Body1 className="text-white">
+          No options matches with your search.
+        </Body1>
+      ) : (
+        <ul className="flex flex-col gap-1 w-full p-0">
+          {results.map((item: string, index: number) => (
+            <ItemDataBox key={index} label={item} onClick={handleClick} />
+          ))}
+        </ul>
       )}
-    </>
+    </div>
   )
 }
 

--- a/src/components/ModalSearchResult/ModalSearchResult.tsx
+++ b/src/components/ModalSearchResult/ModalSearchResult.tsx
@@ -1,0 +1,44 @@
+import ReactDom from 'react-dom'
+
+interface ModalSearchResultProps {
+  show: boolean
+  results: string[]
+  handleClick: (value: string) => void
+  onClose: () => void
+}
+
+const ModalSearchResult: React.FC<ModalSearchResultProps> = ({
+  show,
+  results,
+
+  onClose
+}: ModalSearchResultProps): JSX.Element | null => {
+  const handleClose = (event: React.MouseEvent): void => {
+    if (event.target === event.currentTarget) {
+      onClose()
+    }
+  }
+
+  const portalElement = document.getElementById('portal')
+  if (!portalElement) {
+    return null
+  } else {
+    return ReactDom.createPortal(
+      <>
+        {show && (
+          <div
+            onClick={handleClose}
+            className="w-screen h-screen fixed top-0 left-0 bg-black bg-opacity-50 z-50 flex justify-center items-center"
+          >
+            {results.map((option: string) => (
+              <div key={option}>{option}</div>
+            ))}
+          </div>
+        )}
+      </>,
+      portalElement
+    )
+  }
+}
+
+export default ModalSearchResult

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -266,6 +266,11 @@ const Timer: React.FC<TimerProps> = ({
         }}
       />
       <ModalBlock
+        issueName={
+          currentTicket.name !== ''
+            ? currentTicket.name
+            : currentTrackingTicket.name
+        }
         setIsBlocked={setIsBlocked}
         show={showModalBlock}
         onClose={() => {

--- a/src/data-provider/query.ts
+++ b/src/data-provider/query.ts
@@ -480,6 +480,7 @@ export const useGetIssuesByTitle = (): {
     userId: string
     projectId: string
     issueName: string
+    searchedText: string
   }) => void
   data: Array<{ id: string; name: string }> | undefined
   error: Error | null
@@ -491,18 +492,21 @@ export const useGetIssuesByTitle = (): {
       isProjectManager,
       userId,
       projectId,
-      issueName
+      issueName,
+      searchedText
     }: {
       isProjectManager: boolean
       userId: string
       projectId: string
       issueName: string
+      searchedText: string
     }) => {
       return await ApiService.getIssuesByTitle(
         isProjectManager,
         userId,
         projectId,
-        issueName
+        issueName,
+        searchedText
       )
     },
     retry: false

--- a/src/data-provider/query.ts
+++ b/src/data-provider/query.ts
@@ -474,15 +474,35 @@ export const useAcceptOrDeclineEmail = (
 }
 
 export const useGetIssuesByTitle = (): {
-  mutate: (args: { issueName: string }) => void
+  mutate: (args: {
+    isProjectManager: boolean
+    userId: string
+    projectId: string
+    issueName: string
+  }) => void
   data: Array<{ id: string; name: string }> | undefined
   error: Error | null
   isPending: boolean
   isSuccess: boolean
 } => {
   const { mutate, error, isPending, isSuccess, data } = useMutation({
-    mutationFn: async ({ issueName }: { issueName: string }) => {
-      return await ApiService.getIssuesByTitle(issueName)
+    mutationFn: async ({
+      isProjectManager,
+      userId,
+      projectId,
+      issueName
+    }: {
+      isProjectManager: boolean
+      userId: string
+      projectId: string
+      issueName: string
+    }) => {
+      return await ApiService.getIssuesByTitle(
+        isProjectManager,
+        userId,
+        projectId,
+        issueName
+      )
     },
     retry: false
   })

--- a/src/data-provider/query.ts
+++ b/src/data-provider/query.ts
@@ -472,3 +472,20 @@ export const useAcceptOrDeclineEmail = (
   })
   return { data, error, isLoading }
 }
+
+export const useGetIssuesByTitle = (): {
+  mutate: (args: { issueName: string }) => void
+  data: Array<{ id: string; name: string }> | undefined
+  error: Error | null
+  isPending: boolean
+  isSuccess: boolean
+} => {
+  const { mutate, error, isPending, isSuccess, data } = useMutation({
+    mutationFn: async ({ issueName }: { issueName: string }) => {
+      return await ApiService.getIssuesByTitle(issueName)
+    },
+    retry: false
+  })
+
+  return { mutate, error, isPending, isSuccess, data }
+}

--- a/src/data-provider/service.ts
+++ b/src/data-provider/service.ts
@@ -442,3 +442,13 @@ export const acceptOrDeclineEmail = async (
   //   pmImage: ''
   // }
 }
+
+export const getIssuesByTitle = async (
+  issueName: string
+): Promise<Array<{ id: string; name: string }>> => {
+  const res = await withInterceptors.get(`${url}/issue/${issueName}`)
+  if (res.status === 200) {
+    return res.data
+  }
+  return []
+}

--- a/src/data-provider/service.ts
+++ b/src/data-provider/service.ts
@@ -448,7 +448,8 @@ export const getIssuesByTitle = async (
   isProjectManager: boolean,
   userId: string,
   projectId: string,
-  issueName: string
+  issueName: string,
+  searchedText: string
 ): Promise<Array<{ id: string; name: string }>> => {
   // const res = await withInterceptors.get(`${url}/issue/${issueName}`)
   // if (res.status === 200) {
@@ -460,8 +461,13 @@ export const getIssuesByTitle = async (
     isProjectManager,
     userId,
     projectId,
-    { searchedValue: issueName }
+    { searchedValue: searchedText }
   )
-
-  return issues.map((issue: IssueView) => ({ id: issue.id, name: issue.name }))
+  console.log(issueName)
+  return issues
+    .filter((issue) => issue.name !== issueName)
+    .map((issue: IssueView) => ({
+      id: issue.id,
+      name: issue.name
+    }))
 }

--- a/src/data-provider/service.ts
+++ b/src/data-provider/service.ts
@@ -444,11 +444,23 @@ export const acceptOrDeclineEmail = async (
 }
 
 export const getIssuesByTitle = async (
+  isProjectManager: boolean,
+  userId: string,
+  projectId: string,
   issueName: string
 ): Promise<Array<{ id: string; name: string }>> => {
-  const res = await withInterceptors.get(`${url}/issue/${issueName}`)
-  if (res.status === 200) {
-    return res.data
-  }
-  return []
+  // const res = await withInterceptors.get(`${url}/issue/${issueName}`)
+  // if (res.status === 200) {
+  //   return res.data
+  // }
+  // return []
+
+  const issues = await getIssuesFilteredAndPaginated(
+    isProjectManager,
+    userId,
+    projectId,
+    { searchedValue: issueName }
+  )
+
+  return issues.map((issue: IssueView) => ({ id: issue.id, name: issue.name }))
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 const config = {
-  content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
       colors: {
@@ -31,44 +28,47 @@ const config = {
           300: '#8EFFEB',
           400: '#43FFDD',
           500: '#2AE5C4',
-          700: '#21806F',
+          700: '#21806F'
         },
         secondary: {
           300: '#FFC085',
           400: '#FFA451',
           500: '#E58B37',
-          600: '#CC711E',
+          600: '#CC711E'
         },
         tertiary: {
           300: '#E7BFFF',
           400: '#D795FF',
           500: '#BD7CE5',
-          600: '#A462CC',
-        },
+          600: '#A462CC'
+        }
       },
-      backgroundImage: { // you can use this applying "bg-gradient" class
+      backgroundImage: {
+        // you can use this applying "bg-gradient" class
         gradient: 'linear-gradient(114deg, #D795FF 1.41%, #43FFDD 98.59%)',
         login: "url('/src/assets/Login/LoginBackground.svg')"
       },
       fontFamily: {
-        inter: ["Inter"],
+        inter: ['Inter']
       },
       boxShadow: {
-        '1': '0 4px 4px 0px rgba(182, 143, 189, 0.06)',
-        '2': '0px 2px 20px 0px #43FFDD1A'
+        1: '0 4px 4px 0px rgba(182, 143, 189, 0.06)',
+        2: '0px 2px 20px 0px #43FFDD1A',
+        button: '0 0 10px 2px rgb(36 36 36 / 0.5)',
+        buttonClicked: '0 0 2px 2px rgb(36 36 36 / 0.2)'
       },
       keyframes: {
         slideInLeft: {
-          'from': { transform: 'translateX(-100%)', opacity: '0' },
-          'to': { transform: 'translateX(0)', opacity: '1' },
+          from: { transform: 'translateX(-100%)', opacity: '0' },
+          to: { transform: 'translateX(0)', opacity: '1' }
         }
       },
       animation: {
-        'slideInLeft': 'slideInLeft 1s ease-in-out'
-      },
-    },
+        slideInLeft: 'slideInLeft 1s ease-in-out'
+      }
+    }
   },
-  plugins: [],
+  plugins: []
 }
 
 export default config


### PR DESCRIPTION
# Pull Request

## Description
- Developed an autocomplete input that displays up to 5 options retrieved from the backend (BE).
- Handled errors using a snackbar component.
- Integrated this new component with the ModalBlock component.

## Ticket Link
[[TRI-180]](https://linear.app/tricker-sirius/issue/TRI-180/frontend-implementation-for-card-blocking)

## Steps to Reproduce
1. Run `npm run dev`
2. Select a card.
3. Click on the block button.
4. Attempt to enter different card names (both existing and non-existent).

## Additional Notes (if any)
Data is fetched from the same endpoint as the ticket list. It can be implemented either by fetching more data than necessary, as currently done, or by utilizing the method outlined in the service comments (which the backend has not yet implemented).