### PR TITLE
TRI-182: Frontend routing for direct project access via url parameter

### DIFF
--- a/src/components/HomeWrapperPage/HomeWrapperPage.tsx
+++ b/src/components/HomeWrapperPage/HomeWrapperPage.tsx
@@ -1,7 +1,12 @@
 import NavBar from '@components/NavBar/NavBar'
 import { SidebarNav } from '@components/SidebarNav/SidebarNav'
 import useScreenSize from '@hooks/useScreenSize'
-import { useAppDispatch, useCurrentProjectId, useUser } from '@redux/hooks'
+import {
+  useAppDispatch,
+  useCurrentProjectId,
+  useReceivedProjectId,
+  useUser
+} from '@redux/hooks'
 import { setCurrentProjectId, setUserRole } from '@redux/user'
 import { type UserProjectRole, type DropdownOption } from '@utils/types'
 import React, { useCallback, useEffect, useState } from 'react'
@@ -9,6 +14,7 @@ import { Outlet, useNavigate } from 'react-router-dom'
 
 const HomeWrapperPage: React.FC = (): JSX.Element => {
   const user = useUser()
+  const receivedProjectId = useReceivedProjectId()
   const navigate = useNavigate()
   if (user.id === '') navigate('/login')
   const dispatch = useAppDispatch()
@@ -22,7 +28,9 @@ const HomeWrapperPage: React.FC = (): JSX.Element => {
     })
   )
   const currentProject = dropdownOptions.find(
-    (option: DropdownOption) => option.id === currentProjectId
+    (option: DropdownOption) =>
+      option.id ===
+      (receivedProjectId !== '' ? receivedProjectId : currentProjectId)
   )
 
   const [currentUserRole, setCurrentUserRole] = useState<string>('Developer')

--- a/src/components/Layout/PrivateRoute/PrivateRoute.tsx
+++ b/src/components/Layout/PrivateRoute/PrivateRoute.tsx
@@ -1,19 +1,38 @@
 import { useEffect, useState } from 'react'
 import PageWrapper from './PrivateRouteWrapper'
-import { Navigate, useNavigate } from 'react-router-dom'
+import { Navigate, useNavigate, useLocation } from 'react-router-dom'
 import { useAppDispatch } from '@redux/hooks'
-import { setUser } from '@redux/user'
+import { setUser, setReceivedProjectId } from '@redux/user'
 import { useGetOrCreateUser } from '@data-provider/query'
 import { useSnackBar } from '@components/SnackBarProvider/SnackBarProvider'
+import uuid from 'uuid'
 
 const PrivateRoute = (): JSX.Element => {
   const [isAuthorized, setIsAuthorized] = useState<boolean>(true)
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
   const { showSnackBar } = useSnackBar()
+  const location = useLocation()
 
   const { data, isLoading, error } = useGetOrCreateUser()
   data && dispatch(setUser(data))
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search)
+    const projectId = params.get('projectId')
+
+    if (projectId) {
+      if (!uuid.validate(projectId)) {
+        navigate('/')
+        showSnackBar(
+          'Invalid project ID, reverting to the default project',
+          'error'
+        )
+      } else {
+        dispatch(setReceivedProjectId(projectId))
+      }
+    }
+  }, [location.search, navigate, showSnackBar])
 
   useEffect(() => {
     if (error) {

--- a/src/components/Layout/PrivateRoute/PrivateRoute.tsx
+++ b/src/components/Layout/PrivateRoute/PrivateRoute.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch } from '@redux/hooks'
 import { setUser, setReceivedProjectId } from '@redux/user'
 import { useGetOrCreateUser } from '@data-provider/query'
 import { useSnackBar } from '@components/SnackBarProvider/SnackBarProvider'
-import uuid from 'uuid'
+import { validate } from 'uuid'
 
 const PrivateRoute = (): JSX.Element => {
   const [isAuthorized, setIsAuthorized] = useState<boolean>(true)
@@ -22,7 +22,7 @@ const PrivateRoute = (): JSX.Element => {
     const projectId = params.get('projectId')
 
     if (projectId) {
-      if (!uuid.validate(projectId)) {
+      if (!validate(projectId)) {
         navigate('/')
         showSnackBar(
           'Invalid project ID, reverting to the default project',
@@ -30,6 +30,9 @@ const PrivateRoute = (): JSX.Element => {
         )
       } else {
         dispatch(setReceivedProjectId(projectId))
+        const newParams = new URLSearchParams(location.search)
+        newParams.delete('projectId')
+        navigate(`?${newParams.toString()}`, { replace: true })
       }
     }
   }, [location.search, navigate, showSnackBar])

--- a/src/components/Layout/RoleValidation/RoleValidation.tsx
+++ b/src/components/Layout/RoleValidation/RoleValidation.tsx
@@ -1,30 +1,30 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Navigate, Outlet } from 'react-router-dom'
-import { useCurrentProjectId, useUser } from '@redux/hooks'
+import { useUserRole } from '@redux/hooks'
 import { useSnackBar } from '@components/SnackBarProvider/SnackBarProvider'
-import { type UserProjectRole } from '@utils/types'
+import LoadingPage from '@pages/Loader/LoadingPage'
 
 const RoleValidation = (): JSX.Element => {
   const { showSnackBar } = useSnackBar()
-  const user = useUser()
-  const currentProjectId = useCurrentProjectId()
-
-  const currentProject: UserProjectRole | undefined =
-    user.projectsRoleAssigned.find(
-      (project: UserProjectRole) => project.projectId === currentProjectId
-    )
+  const userRole = useUserRole()
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    if (currentProject && currentProject.role?.name !== 'Project Manager') {
-      showSnackBar('You are not authorized to access this page', 'error')
+    if (userRole !== '') {
+      setIsLoading(false)
     }
-  }, [currentProject, showSnackBar])
+  }, [userRole])
 
-  if (currentProject && currentProject.role?.name === 'Project Manager') {
-    return <Outlet />
+  if (isLoading) {
+    return <LoadingPage />
   }
 
-  return <Navigate to="/" replace />
+  if (userRole !== 'Project Manager') {
+    showSnackBar('You are not authorized to access this page', 'error')
+    return <Navigate to="/" replace />
+  }
+
+  return <Outlet />
 }
 
 export default RoleValidation

--- a/src/data-provider/service.ts
+++ b/src/data-provider/service.ts
@@ -137,8 +137,7 @@ export const postProjectIntegrationRequest = async (
       projectId: authorizationRequest.projectId,
       integratorId: authorizationRequest.integratorId,
       members: authorizationRequest.members,
-      organizationName: authorizationRequest.organizationName,
-      issueProviderName: authorizationRequest.issueProviderName
+      organizationName: authorizationRequest.organizationName
     }
   )
   if (res.status === 201) {

--- a/src/redux/hooks.tsx
+++ b/src/redux/hooks.tsx
@@ -24,6 +24,8 @@ export const useCurrentProjectId = (): string =>
   useAppSelector((state) => state.user.currentProjectId)
 export const useUserRole = (): string =>
   useAppSelector((state) => state.user.userRole)
+export const useReceivedProjectId = (): string =>
+  useAppSelector((state) => state.user.receivedProjectId)
 export const useUser = (): User => useAppSelector((state) => state.user.user)
 export const useApiKey = (): { provider: string; value: string } =>
   useAppSelector((state) => state.user.apiKey)

--- a/src/redux/user.tsx
+++ b/src/redux/user.tsx
@@ -11,6 +11,7 @@ import {
 interface InitialStateType {
   user: User
   userRole: string
+  receivedProjectId: string
   currentTicket: IssueView
   currentProjectId: string
   currentStep: number
@@ -39,6 +40,7 @@ export const initialState: InitialStateType = {
     emittedManualTimeModification: []
   },
   userRole: '',
+  receivedProjectId: '',
   currentTicket: {
     id: '',
     assignee: null,
@@ -86,7 +88,7 @@ const userSlice = createSlice({
       state.userRole = action.payload
     },
     setReceivedProjectId: (state, action: PayloadAction<string>) => {
-      state.userRole = action.payload
+      state.receivedProjectId = action.payload
     },
     setCurrentTicket: (state, action: PayloadAction<IssueView>) => {
       state.currentTicket = action.payload

--- a/src/redux/user.tsx
+++ b/src/redux/user.tsx
@@ -85,6 +85,9 @@ const userSlice = createSlice({
     setUserRole: (state, action: PayloadAction<string>) => {
       state.userRole = action.payload
     },
+    setReceivedProjectId: (state, action: PayloadAction<string>) => {
+      state.userRole = action.payload
+    },
     setCurrentTicket: (state, action: PayloadAction<IssueView>) => {
       state.currentTicket = action.payload
     },
@@ -115,6 +118,7 @@ const userSlice = createSlice({
 export const {
   setUser,
   setUserRole,
+  setReceivedProjectId,
   setCurrentTicket,
   setCurrentProjectId,
   setCurrentStep,


### PR DESCRIPTION
# Pull Request

## Description
The following features were implemented:
- **Handling URL with project parameter**: Route logic was improved to allow direct access to specific projects via a URL parameter. Now, by providing a valid project ID in the URL, the application validates the ID and loads data for the corresponding project.
- **UUID validation in URL**: Validation was added to ensure that the project ID provided in the URL is a valid UUID. In case it's not valid, the application reverts to the default project and displays an error message to the user.
- **Improved user role validation**: The RoleValidation component was optimized to better handle cases where the user role is not immediately available after a page refresh. Now, a loading indicator is displayed until the user role is set, avoiding incorrect redirections.

## Ticket Link
[[TRI-182]](https://linear.app/tricker-sirius/issue/TRI-182/frontend-routing-for-direct-project-access-via-url-parameter)

## Steps to Reproduce
1. Run `npm run dev`
2. Integrate more than one project to see how it switch the project in based of the projectId sent as query param.
3. Go to `localhost:5173/?projectId='<<your_project_id>>'` and check if the project has switched
4. Go to `localhost:5173/?projectId='<<incorrect_projectId>>'` and check that it autoselects the first project.
5. Go to `localhost:5173/?projectId='<<not_uuid>>'` and check that it autoselects the first project and shows you an error message.
6. You can also check this with the another routes: /`my-team?projectId...`, `/stats` and `/projects`
7. Something interesting to test is to integrate a project inside the app and click on `Open in Tricker` at the received email to see if it redirects you to Tricker in the correspondent integrated project.