### PR TITLE
TRI-241: Disable already added projects with 'added' indicator

### DIFF
--- a/src/components/ModalAddNewProject/SelectProject.tsx
+++ b/src/components/ModalAddNewProject/SelectProject.tsx
@@ -47,7 +47,7 @@ const SelectProject: React.FC<SelectProjectProps> = ({
       apiKey.value,
       enabled
     )
-  console.log(projects)
+
   const handleSelection = (project: ProjectPreIntegrated): void => {
     setSelectedProject(project)
   }
@@ -102,9 +102,9 @@ const SelectProject: React.FC<SelectProjectProps> = ({
                   {projects?.map((project: ProjectPreIntegrated) => (
                     <div
                       key={project.providerProjectId}
-                      className={`flex items-center gap-4 p-4 hover:bg-gray-500 ${project.alreadyIntegrated === true ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+                      className={`flex items-center gap-4 p-4 hover:bg-gray-500 ${project.state === 'ADDED' ? 'cursor-not-allowed' : 'cursor-pointer'}`}
                       onClick={() => {
-                        if (project.alreadyIntegrated === true) return
+                        if (project.state === 'ADDED') return
                         setSelectedProject(project)
                         handleSelection(project)
                       }}
@@ -113,6 +113,7 @@ const SelectProject: React.FC<SelectProjectProps> = ({
                         handleChecked={() => {}}
                         id={project.providerProjectId}
                         selectedValue={selectedProject?.providerProjectId || ''}
+                        disabled={project.state === 'ADDED'}
                       />
                       {project.image && project.image !== '' ? (
                         <img
@@ -131,12 +132,12 @@ const SelectProject: React.FC<SelectProjectProps> = ({
                       )}
                       <div className="flex w-full justify-between items-center">
                         <Body1
-                          className={`${project.alreadyIntegrated === true ? 'text-gray-300/80 ' : 'text-white '}`}
+                          className={`${project.state === 'ADDED' ? 'text-gray-300/80 ' : 'text-white '}`}
                         >
                           {project.name}
                         </Body1>
                         <HelperText className="text-gray-300/80">
-                          {project.alreadyIntegrated === true ? 'Added' : ''}
+                          {project.state === 'ADDED' ? 'Added' : ''}
                         </HelperText>
                       </div>
                     </div>

--- a/src/components/ModalAddNewProject/SelectProject.tsx
+++ b/src/components/ModalAddNewProject/SelectProject.tsx
@@ -47,7 +47,7 @@ const SelectProject: React.FC<SelectProjectProps> = ({
       apiKey.value,
       enabled
     )
-
+  console.log(projects)
   const handleSelection = (project: ProjectPreIntegrated): void => {
     setSelectedProject(project)
   }

--- a/src/components/ModalAddNewProject/SelectProvider.tsx
+++ b/src/components/ModalAddNewProject/SelectProvider.tsx
@@ -60,10 +60,10 @@ const SelectProvider: React.FC<SelectProviderProps> = ({
   useEffect(() => {
     if (isSuccess && data && enabled) {
       data.sort((a, b) => {
-        if (a.alreadyIntegrated === true && b.alreadyIntegrated === false) {
+        if (a.state === 'ADDED' && b.state === 'NOT_ADDED') {
           return -1
         }
-        if (a.alreadyIntegrated === false && b.alreadyIntegrated === true) {
+        if (a.state === 'NOT_ADDED' && b.state === 'ADDED') {
           return 1
         }
         return 0

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -33,7 +33,7 @@ export const Primary: Story = {
     selectedValue: '0'
   },
   render: (args) => (
-    <>
+    <div className="flex gap-1">
       <RadioButton
         id={'0'}
         selectedValue={args.selectedValue}
@@ -49,6 +49,35 @@ export const Primary: Story = {
         selectedValue={args.selectedValue}
         handleChecked={() => {}}
       />
-    </>
+    </div>
+  )
+}
+
+export const Disabled: Story = {
+  tags: ['autodocs'],
+  args: {
+    selectedValue: '0'
+  },
+  render: (args) => (
+    <div className="flex gap-1">
+      <RadioButton
+        id={'0'}
+        selectedValue={args.selectedValue}
+        handleChecked={() => {}}
+        disabled
+      />
+      <RadioButton
+        id={'1'}
+        selectedValue={args.selectedValue}
+        handleChecked={() => {}}
+        disabled
+      />
+      <RadioButton
+        id={'2'}
+        selectedValue={args.selectedValue}
+        handleChecked={() => {}}
+        disabled
+      />
+    </div>
   )
 }

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -11,7 +11,7 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
   id,
   handleChecked,
   selectedValue,
-  disabled = true
+  disabled = false
 }) => {
   const checked = selectedValue === id
   const handleChange = (): void => {

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -4,12 +4,14 @@ export interface RadioButtonProps {
   id: string
   handleChecked: (id: string) => void
   selectedValue: string
+  disabled?: boolean
 }
 
 export const RadioButton: React.FC<RadioButtonProps> = ({
   id,
   handleChecked,
-  selectedValue
+  selectedValue,
+  disabled = true
 }) => {
   const checked = selectedValue === id
   const handleChange = (): void => {
@@ -18,17 +20,20 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 
   return (
     <div>
-      <label className="cursor-pointer">
+      <label className={disabled ? 'cursor-not-allowed' : 'cursor-pointer'}>
         <input
           id={`radio-button-${id}`}
           type="radio"
           className="peer sr-only"
           checked={checked}
           onChange={handleChange}
+          disabled={disabled}
         />
-        <div className="p-0.5 border border-gray-300 peer-checked:border-primary-400 rounded-full">
+        <div
+          className={`p-0.5 border border-gray-${disabled ? '400' : '300'} peer-checked:border-${disabled ? 'gray' : 'primary'}-400 rounded-full`}
+        >
           <div
-            className={`h-2 w-2 rounded-full bg-${checked ? 'primary-400' : 'transparent'}`}
+            className={`h-2 w-2 rounded-full bg-${disabled ? 'gray-400' : checked ? 'primary-400' : 'transparent'}`}
           />
         </div>
       </label>

--- a/src/components/TeamMemberManagement/TeamMember.stories.tsx
+++ b/src/components/TeamMemberManagement/TeamMember.stories.tsx
@@ -15,7 +15,8 @@ const actualUser: MemberPreIntegrated = {
 const project: ProjectPreIntegrated = {
   providerProjectId: 'projectId',
   name: 'Tricker',
-  image: null
+  image: null,
+  state: 'NOT_ADDED'
 }
 
 const queryClient = new QueryClient()

--- a/src/data-provider/service.ts
+++ b/src/data-provider/service.ts
@@ -137,8 +137,7 @@ export const postProjectIntegrationRequest = async (
       projectId: authorizationRequest.projectId,
       integratorId: authorizationRequest.integratorId,
       members: authorizationRequest.members,
-      organizationName: authorizationRequest.organizationName,
-      issueProviderName: authorizationRequest.issueProviderName
+      organizationName: authorizationRequest.organizationName
     }
   )
   if (res.status === 201) {

--- a/src/utils/types.tsx
+++ b/src/utils/types.tsx
@@ -208,7 +208,7 @@ export interface ProjectView {
 }
 
 export interface ProjectPreIntegrated {
-  alreadyIntegrated?: boolean
+  state: 'ADDED' | 'NOT_ADDED'
   providerProjectId: string
   name: string
   image: string | null


### PR DESCRIPTION
# Pull Request

## Description
- Added state management for the disabled status of the radio button.
- Made the design to visually indicate added projects with a disabled state.
- Displayed the "added" text indicator next to disabled project options.

## Ticket Link
[[TRI-241]](https://linear.app/tricker-sirius/issue/TRI-241/disable-already-added-projects-with-added-indicator)

## Steps to Reproduce
1. Run `npm run dev`
2. Try to integrate a project.
3. Check how an already integrated project cannot be selected.
<img width="785" alt="image" src="https://github.com/sirius-valley/tricker-front/assets/112835662/a09229cc-08d2-419b-9909-e8ce32d25645">
